### PR TITLE
added message param to override default

### DIFF
--- a/lib/puppet/provider/assert/ruby.rb
+++ b/lib/puppet/provider/assert/ruby.rb
@@ -5,11 +5,16 @@ Puppet::Type.type(:assert).provide(:ruby) do
     false
   end
 
+  def assert_message
+    value = resource[:message] || resource[:name]
+    "Assert Failed: #{value}"
+  end
+
   def create
-    raise Puppet::Error, "Assert Failed: #{resource[:name]}" if not resource[:condition]
+    raise Puppet::Error, assert_message if not resource[:condition]
   end
 
   def destroy
-    raise Puppet::Error, "Assert Failed: #{resource[:name]}" if not resource[:condition]
+    raise Puppet::Error, assert_message if not resource[:condition]
   end
 end

--- a/lib/puppet/type/assert.rb
+++ b/lib/puppet/type/assert.rb
@@ -17,7 +17,11 @@ Puppet::Type.newtype('assert') do
   newparam(:name, :namevar => true) do
     desc "The name of the assert."
   end
-  
+
+  newparam(:message) do
+    desc 'The message to be displayed when the assert fails'
+  end
+
   newparam(:condition) do
     desc "The condition. Pass true to succeed and false to fail."
   end


### PR DESCRIPTION
This adds the ability to make the title of the resource and message different.

``` puppet
 assert{'linux_test':
    condition => $::linux_test == 'pass',
    message   => 'Linux control 12345 did not pass'
  }
```
